### PR TITLE
Add deployment footer with branch name and deploy time information (#10)

### DIFF
--- a/build-for-pages.sh
+++ b/build-for-pages.sh
@@ -117,6 +117,9 @@ npm install
 
 # Build the app
 echo "Building application..."
+# Set deploy time for build
+export DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "Setting deploy time: $DEPLOY_TIME"
 npm run build
 
 # Move the built files to the output directory

--- a/deploy-to-pages.sh
+++ b/deploy-to-pages.sh
@@ -30,6 +30,10 @@ cat > temp-vite.config.ts <<EOF
 $(cat vite.config.ts | sed "s/build: {/build: {\n    base: '\/${REPO_NAME}\/',/")
 EOF
 
+# Set deploy time for build
+export DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "Setting deploy time: $DEPLOY_TIME"
+
 # Build with temporary config
 mv temp-vite.config.ts vite.config.ts
 npm run build

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,6 +10,10 @@ rm -rf dist
 
 # Build the frontend
 echo "Compiling frontend..."
+# Set deploy time for build
+export DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "Setting deploy time: $DEPLOY_TIME"
+
 npm install -f # force because there is a known mismatch of shadcn and react 19 - https://ui.shadcn.com/docs/react-19
 npm run build
 

--- a/scripts/capture-deploy-info.sh
+++ b/scripts/capture-deploy-info.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Capture deployment information
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+DEPLOY_TIME=${DEPLOY_TIME:-$BUILD_TIME}
+
+# Export as environment variables for Vite
+export VITE_GIT_BRANCH="$BRANCH_NAME"
+export VITE_BUILD_TIME="$BUILD_TIME"
+export VITE_DEPLOY_TIME="$DEPLOY_TIME"
+
+echo "Deployment Info:"
+echo "  Branch: $BRANCH_NAME"
+echo "  Build Time: $BUILD_TIME"
+echo "  Deploy Time: $DEPLOY_TIME"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { DeploymentFooter } from "@/components/DeploymentFooter";
 import { 
   AggregatedData, 
   CopilotUsageData, 
@@ -690,6 +691,7 @@ function App() {
         </div>
       )}
       <Toaster position="top-right" />
+      <DeploymentFooter />
     </div>
   );
 }

--- a/src/components/DeploymentFooter.tsx
+++ b/src/components/DeploymentFooter.tsx
@@ -1,0 +1,48 @@
+import { getDeploymentInfo } from "@/lib/deployment-info";
+
+export function DeploymentFooter() {
+  const deployInfo = getDeploymentInfo();
+  
+  // Don't show footer if no deployment info is available
+  if (deployInfo.branchName === 'unknown' && deployInfo.deployTime === 'unknown') {
+    return null;
+  }
+  
+  const formatDeployTime = (deployTime: string) => {
+    if (deployTime === 'unknown') return 'Unknown';
+    try {
+      // Try to parse and format the timestamp
+      const date = new Date(deployTime);
+      if (isNaN(date.getTime())) return deployTime; // Return as-is if not parseable
+      return date.toLocaleString();
+    } catch {
+      return deployTime; // Return as-is if parsing fails
+    }
+  };
+
+  return (
+    <footer className="mt-8 py-4 border-t border-border">
+      <div className="container max-w-7xl mx-auto px-4">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-4">
+            {deployInfo.branchName !== 'unknown' && (
+              <span>
+                Branch: <span className="font-mono text-foreground">{deployInfo.branchName}</span>
+              </span>
+            )}
+            {deployInfo.deployTime !== 'unknown' && (
+              <span>
+                Deployed: <span className="text-foreground">{formatDeployTime(deployInfo.deployTime)}</span>
+              </span>
+            )}
+          </div>
+          {deployInfo.buildTime !== 'unknown' && (
+            <span className="text-xs">
+              Built: {formatDeployTime(deployInfo.buildTime)}
+            </span>
+          )}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/lib/deployment-info.ts
+++ b/src/lib/deployment-info.ts
@@ -1,0 +1,15 @@
+// Deployment information that gets injected at build time
+export interface DeploymentInfo {
+  branchName: string;
+  deployTime: string;
+  buildTime: string;
+}
+
+// Get deployment information from environment variables injected at build time
+export function getDeploymentInfo(): DeploymentInfo {
+  return {
+    branchName: import.meta.env.VITE_GIT_BRANCH || 'unknown',
+    deployTime: import.meta.env.VITE_DEPLOY_TIME || 'unknown',
+    buildTime: import.meta.env.VITE_BUILD_TIME || 'unknown',
+  };
+}

--- a/src/test/deployment-footer.test.tsx
+++ b/src/test/deployment-footer.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DeploymentFooter } from '@/components/DeploymentFooter';
+
+// Mock the deployment info module
+vi.mock('@/lib/deployment-info', () => ({
+  getDeploymentInfo: vi.fn(),
+}));
+
+import * as deploymentInfoModule from '@/lib/deployment-info';
+
+describe('DeploymentFooter', () => {
+  const mockGetDeploymentInfo = vi.mocked(deploymentInfoModule.getDeploymentInfo);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('should display branch name and deploy time when deployment info is available', () => {
+    const mockDeployInfo = {
+      branchName: 'main',
+      deployTime: '2025-06-28T10:00:00Z',
+      buildTime: '2025-06-28T10:00:00Z',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    expect(screen.getByText('Branch:')).toBeInTheDocument();
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.getByText('Deployed:')).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('Built:'))).toBeInTheDocument();
+  });
+
+  it('should display feature branch name correctly', () => {
+    const mockDeployInfo = {
+      branchName: 'feature/footer-implementation',
+      deployTime: '2025-06-28T10:00:00Z',
+      buildTime: '2025-06-28T10:00:00Z',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    expect(screen.getByText('feature/footer-implementation')).toBeInTheDocument();
+  });
+
+  it('should not render when deployment info is unknown', () => {
+    const mockDeployInfo = {
+      branchName: 'unknown',
+      deployTime: 'unknown',
+      buildTime: 'unknown',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    const { container } = render(<DeploymentFooter />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render when only branch name is available', () => {
+    const mockDeployInfo = {
+      branchName: 'main',
+      deployTime: 'unknown',
+      buildTime: 'unknown',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    expect(screen.getByText('Branch:')).toBeInTheDocument();
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.queryByText('Deployed:')).not.toBeInTheDocument();
+    expect(screen.queryByText('Built:')).not.toBeInTheDocument();
+  });
+
+  it('should render when only deploy time is available', () => {
+    const mockDeployInfo = {
+      branchName: 'unknown',
+      deployTime: '2025-06-28T10:00:00Z',
+      buildTime: '2025-06-28T10:00:00Z',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    expect(screen.queryByText('Branch:')).not.toBeInTheDocument();
+    expect(screen.getByText('Deployed:')).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('Built:'))).toBeInTheDocument();
+  });
+
+  it('should format date correctly when valid ISO date is provided', () => {
+    const mockDeployInfo = {
+      branchName: 'main',
+      deployTime: '2025-06-28T10:30:45Z',
+      buildTime: '2025-06-28T10:30:45Z',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    // Check that the dates are formatted (should have been converted from ISO)
+    expect(screen.getByText((content) => content.includes('Deployed:'))).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('Built:'))).toBeInTheDocument();
+    
+    // Check that the formatted dates contain digits (meaning they were processed)
+    // Using getAllByText since there are multiple elements with the date
+    const elementsWithDate = screen.getAllByText((content) => content.includes('28') || content.includes('2025'));
+    expect(elementsWithDate.length).toBeGreaterThan(0);
+  });
+
+  it('should handle invalid date strings gracefully', () => {
+    const mockDeployInfo = {
+      branchName: 'main',
+      deployTime: 'invalid-date',
+      buildTime: 'another-invalid-date',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    render(<DeploymentFooter />);
+
+    // Should display the raw string when date parsing fails
+    expect(screen.getByText('invalid-date')).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('another-invalid-date'))).toBeInTheDocument();
+  });
+
+  it('should have correct CSS classes for styling', () => {
+    const mockDeployInfo = {
+      branchName: 'test-styling-branch',
+      deployTime: '2025-06-28T10:00:00Z',
+      buildTime: '2025-06-28T10:00:00Z',
+    };
+    
+    mockGetDeploymentInfo.mockReturnValue(mockDeployInfo);
+
+    const { container } = render(<DeploymentFooter />);
+    
+    const footer = container.querySelector('footer');
+    expect(footer).toHaveClass('mt-8', 'py-4', 'border-t', 'border-border');
+    
+    const branchElement = screen.getByText('test-styling-branch');
+    expect(branchElement).toHaveClass('font-mono', 'text-foreground');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,29 @@ import { defineConfig } from 'vite';
 import tailwindcss from "@tailwindcss/vite";
 import react from '@vitejs/plugin-react-swc';
 import { resolve } from 'path';
+import { execSync } from 'child_process';
+
+// Get deployment information at build time
+const getDeploymentInfo = () => {
+  try {
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    const buildTime = new Date().toISOString();
+    const deployTime = process.env.DEPLOY_TIME || buildTime;
+    
+    return {
+      VITE_GIT_BRANCH: branchName,
+      VITE_BUILD_TIME: buildTime,
+      VITE_DEPLOY_TIME: deployTime,
+    };
+  } catch (error) {
+    console.warn('Could not get git information:', error.message);
+    return {
+      VITE_GIT_BRANCH: 'unknown',
+      VITE_BUILD_TIME: new Date().toISOString(),
+      VITE_DEPLOY_TIME: process.env.DEPLOY_TIME || new Date().toISOString(),
+    };
+  }
+};
 
 // Get the GitHub repository name from package.json to use as base path
 // This makes assets load correctly on GitHub Pages
@@ -28,6 +51,15 @@ const getBasePath = () => {
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: getBasePath(),
+  define: {
+    // Inject deployment info as constants
+    ...Object.fromEntries(
+      Object.entries(getDeploymentInfo()).map(([key, value]) => [
+        `import.meta.env.${key}`, 
+        JSON.stringify(value)
+      ])
+    ),
+  },
   build: {
     outDir: 'dist',
     sourcemap: false,

--- a/vite.github-pages.config.ts
+++ b/vite.github-pages.config.ts
@@ -2,6 +2,29 @@ import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from 'path';
+import { execSync } from 'child_process';
+
+// Get deployment information at build time
+const getDeploymentInfo = () => {
+  try {
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf-8' }).trim();
+    const buildTime = new Date().toISOString();
+    const deployTime = process.env.DEPLOY_TIME || buildTime;
+    
+    return {
+      VITE_GIT_BRANCH: branchName,
+      VITE_BUILD_TIME: buildTime,
+      VITE_DEPLOY_TIME: deployTime,
+    };
+  } catch (error) {
+    console.warn('Could not get git information:', error.message);
+    return {
+      VITE_GIT_BRANCH: 'unknown',
+      VITE_BUILD_TIME: new Date().toISOString(),
+      VITE_DEPLOY_TIME: process.env.DEPLOY_TIME || new Date().toISOString(),
+    };
+  }
+};
 
 // Simple Vite config for GitHub Pages deployment
 export default defineConfig({
@@ -9,6 +32,15 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
+  define: {
+    // Inject deployment info as constants
+    ...Object.fromEntries(
+      Object.entries(getDeploymentInfo()).map(([key, value]) => [
+        `import.meta.env.${key}`, 
+        JSON.stringify(value)
+      ])
+    ),
+  },
   build: {
     outDir: 'dist',
     // Set external dependencies that shouldn't be bundled


### PR DESCRIPTION
This pull request introduces functionality to capture and display deployment information, including branch name, build time, and deploy time. It also adds a `DeploymentFooter` component to the application, updates build scripts to set deploy-time environment variables, and ensures deployment info is injected into the build process. Comprehensive tests for the `DeploymentFooter` component are included.

### Deployment Information Capture and Injection:

* [`scripts/capture-deploy-info.sh`](diffhunk://#diff-1861b0045af4a571f5880d4ebd34fb412f3d1627c5670f4bcd673b7a4bfc0255R1-R16): Added a script to capture deployment information (branch name, build time, and deploy time) and export them as environment variables for use in the build process.
* `vite.config.js` and `vite.github-pages.config.ts`: Added logic to inject deployment information as constants into the build using `import.meta.env`. This ensures deployment info is accessible throughout the app. [[1]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26R5-R27) [[2]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26R54-R62) [[3]](diffhunk://#diff-9fd3984b4fb5186090baaf97feead8a8b0092ed86c96365e2fa6329df6a3a4c2R5-R43)

### Deployment Footer Integration:

* [`src/components/DeploymentFooter.tsx`](diffhunk://#diff-342f4a28113d52738e4b9bd7481d3995b5d232015a9d7888bbb383d355392c42R1-R48): Added a new `DeploymentFooter` component to display branch name, deploy time, and build time in the app's footer. Includes logic to format timestamps and handle missing or invalid data gracefully.
* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R14): Integrated the `DeploymentFooter` component into the main application layout. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R14) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R694)

### Build Script Updates:

* `build-for-pages.sh`, `deploy-to-pages.sh`, and `deploy.sh`: Updated scripts to set the `DEPLOY_TIME` environment variable during the build process, ensuring consistent deployment info across builds. [[1]](diffhunk://#diff-8bce4d1492f40e742b108c8dd7faef34a389a7442d21e150bd5100209212b8d6R120-R122) [[2]](diffhunk://#diff-5e84949ad8a0ddac821fec7a25075dff3faad4e9b88131816acf9221915a36a0R33-R36) [[3]](diffhunk://#diff-30883d1df2fc62f59d66255a70dc05f60d3d4ef4d3957e6e3e38e62f6e471bd0R13-R16)

### Testing Enhancements:

* [`src/test/deployment-footer.test.tsx`](diffhunk://#diff-49ed58c4d890628fe44268aa870260102f612510631da742db5b1e6246ea8444R1-R156): Added comprehensive tests for the `DeploymentFooter` component, covering scenarios such as missing data, formatting of valid and invalid timestamps, and CSS styling validation.

### Utility for Deployment Info:

* [`src/lib/deployment-info.ts`](diffhunk://#diff-1c450577e126658a8503d07b2a1be522e4b7f5d2975e110100f574113d7d3eb3R1-R15): Added a utility function to retrieve deployment information from environment variables injected at build time. Add deployment footer with branch name and deploy time information
