### PR TITLE
Add owner and repo to tag-rajbos workflow

### DIFF
--- a/.github/workflows/tag-rajbos.yml
+++ b/.github/workflows/tag-rajbos.yml
@@ -25,3 +25,5 @@ jobs:
           team: rajbos
           issue: ${{ github.event.issue.number }}
           pr: ${{ github.event.pull_request.number }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/tag-rajbos.yml` workflow by adding two new parameters to the `jobs:` section. These parameters provide additional repository context for the workflow.

* Added `owner` and `repo` fields to the workflow job parameters to expose the repository owner and name for use in subsequent workflow steps.