### PR TITLE
feat: Add privacy banner to reassure users about data security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,17 +3938,6 @@
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
-        "node_modules/@types/node": {
-            "version": "24.0.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-            "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~7.8.0"
-            }
-        },
         "node_modules/@types/react": {
             "version": "19.1.8",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -8537,14 +8526,6 @@
                 "ulid": "dist/cli.js"
             }
         },
-        "node_modules/undici-types": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/unicorn-magic": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -9077,20 +9058,6 @@
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-            "license": "ISC",
-            "optional": true,
-            "peer": true,
-            "bin": {
-                "yaml": "bin.mjs"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef, DragEvent, useEffect } from "react";
 import { Upload, GithubLogo, CircleNotch } from "@phosphor-icons/react";
-import { UserSquare, ChevronRight } from "lucide-react";
+import { UserSquare, ChevronRight, Shield } from "lucide-react";
 import { toast, Toaster } from "sonner";
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
@@ -474,6 +474,26 @@ function App() {
           </Button>
         </div>
       </header>
+      
+      {/* Privacy Banner */}
+      <Card className="mb-6 border-green-200 bg-green-50 dark:bg-green-950/10 dark:border-green-800">
+        <div className="p-4">
+          <div className="flex items-center gap-3">
+            <Shield className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-1">
+                <h3 className="text-sm font-medium text-green-800 dark:text-green-300">
+                  Your Data Stays Private
+                </h3>
+              </div>
+              <p className="text-xs text-green-700 dark:text-green-400">
+                All CSV data is processed locally in your browser. We never upload, store, or transmit your data to any server. 
+                Your usage information remains completely private and secure on your machine.
+              </p>
+            </div>
+          </div>
+        </div>
+      </Card>
       
       {!(data && data.length > 0) && (
         <Card className="mb-8">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/lib/utils";
 
 function App() {
+  const [showPrivacyBanner, setShowPrivacyBanner] = useState(true);
   const [data, setData] = useState<CopilotUsageData[] | null>(null);
   const [aggregatedData, setAggregatedData] = useState<AggregatedData[]>([]);
   const [uniqueModels, setUniqueModels] = useState<string[]>([]);
@@ -474,26 +475,37 @@ function App() {
           </Button>
         </div>
       </header>
-      
+
       {/* Privacy Banner */}
-      <Card className="mb-6 border-green-200 bg-green-50 dark:bg-green-950/10 dark:border-green-800">
-        <div className="p-4">
-          <div className="flex items-center gap-3">
-            <Shield className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
+      {showPrivacyBanner && (
+        <Card className="mb-6 border border-green-300 bg-white/90 dark:bg-zinc-900/90 shadow-sm dark:border-green-700 relative">
+          <button
+            aria-label="Close privacy banner"
+            className="absolute top-3 right-3 text-green-700 dark:text-green-300 hover:text-red-500 dark:hover:text-red-400 transition-colors rounded-full p-1 focus:outline-none focus:ring-2 focus:ring-green-400"
+            onClick={() => setShowPrivacyBanner(false)}
+            type="button"
+          >
+            <span className="sr-only">Close</span>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M6 6L14 14M14 6L6 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          </button>
+          <div className="p-5 sm:p-6 flex items-center gap-4">
+            <Shield className="h-6 w-6 text-green-700 dark:text-green-300 flex-shrink-0" />
             <div className="flex-1">
               <div className="flex items-center gap-2 mb-1">
-                <h3 className="text-sm font-medium text-green-800 dark:text-green-300">
+                <h3 className="text-base sm:text-lg font-semibold text-green-900 dark:text-green-200 tracking-tight">
                   Your Data Stays Private
                 </h3>
               </div>
-              <p className="text-xs text-green-700 dark:text-green-400">
-                All CSV data is processed locally in your browser. We never upload, store, or transmit your data to any server. 
-                Your usage information remains completely private and secure on your machine.
+              <p className="text-sm sm:text-base font-medium text-gray-800 dark:text-gray-100 leading-relaxed">
+                All CSV data is <span className="font-bold text-green-800 dark:text-green-300">processed locally in your browser</span>. We <span className="font-bold">never upload, store, or transmit your data</span> to any server.<br className="hidden sm:block" />
+                Your usage information remains <span className="font-bold text-green-800 dark:text-green-300">completely private and secure</span> on your machine.
               </p>
             </div>
           </div>
-        </div>
-      </Card>
+        </Card>
+      )}
       
       {!(data && data.length > 0) && (
         <Card className="mb-8">


### PR DESCRIPTION
This pull request adds a privacy banner to the main application page to reassure users that their CSV data is processed locally and never leaves their browser. It also introduces the `Shield` icon from `lucide-react` to visually reinforce the privacy message.

**User interface improvements:**

* Added a privacy banner to the `App` component, clearly stating that all CSV data is processed locally and never uploaded or stored on any server. This banner uses a green color scheme and includes the `Shield` icon for emphasis.

**Dependency updates:**

* Imported the `Shield` icon from `lucide-react` in `src/App.tsx` to support the new privacy banner.

# Example screenshot

<img width="944" height="706" alt="image" src="https://github.com/user-attachments/assets/35e7c5c7-eb02-46a0-9ce7-c598d2d8590b" />

Needs a touchup on colors to make things readable