### PR TITLE
Fix Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,14 +107,14 @@
                 "@rollup/plugin-commonjs": "^28.0.3",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.1",
-                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-terser": "^1.0.0",
                 "@rollup/plugin-typescript": "^12.1.2",
                 "rollup-plugin-delete": "^3.0.1",
                 "spark-agent": "file:../spark-agent",
                 "spark-designer": "file:../spark-designer",
                 "tslib": "^2.8.1",
                 "ulid": "^3.0.0",
-                "vite": "^6.2.0",
+                "vite": "^6.4.2",
                 "zod": "^3.24.2"
             },
             "peerDependencies": {
@@ -3327,9 +3327,9 @@
             }
         },
         "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3386,18 +3386,18 @@
             }
         },
         "node_modules/@rollup/plugin-terser": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-            "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+            "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "serialize-javascript": "^6.0.1",
+                "serialize-javascript": "^7.0.3",
                 "smob": "^1.0.0",
                 "terser": "^5.17.4"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
                 "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -3459,9 +3459,9 @@
             }
         },
         "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7758,9 +7758,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8427,9 +8427,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -9482,12 +9482,12 @@
                 "@rollup/plugin-commonjs": "^28.0.3",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.1",
-                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-terser": "^1.0.0",
                 "@rollup/plugin-typescript": "^12.1.2",
                 "rollup-plugin-delete": "^3.0.1",
                 "tslib": "^2.8.1",
                 "ulid": "^3.0.0",
-                "vite": "^6.2.0",
+                "vite": "^6.4.2",
                 "zod": "^3.24.2"
             },
             "peerDependencies": {
@@ -9995,9 +9995,9 @@
             }
         },
         "packages/spark-tools/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10008,9 +10008,9 @@
             }
         },
         "packages/spark-tools/node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10101,7 +10101,7 @@
                 "@rollup/plugin-commonjs": "^28.0.3",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.1",
-                "@rollup/plugin-terser": "^0.4.4",
+                "@rollup/plugin-terser": "^1.0.0",
                 "@rollup/plugin-typescript": "^12.1.2",
                 "rollup-plugin-delete": "^3.0.1",
                 "ulid": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
         "vite": "^8.0.10",
         "vitest": "^4.1.2"
     },
+    "overrides": {
+        "micromatch": {
+            "picomatch": "2.3.2"
+        }
+    },
     "workspaces": {
         "packages": [
             "packages/*"


### PR DESCRIPTION
## Summary
- update the lockfile's Spark-linked toolchain entries to safe versions of Vite, `@rollup/plugin-terser`, `serialize-javascript`, and `picomatch`
- pin the legacy `micromatch` -> `picomatch` resolution to `2.3.2` with an npm override
- clear the current open npm Dependabot alerts recorded in `package-lock.json`

## Validation
- `npm audit`
- `npm run build`
- `npm run test:run` *(still has the existing unrelated failure in `src/test/user-analysis.test.ts` for `should return correct weekly breakdown format`)*