### PR TITLE
feat: multi-file CSV upload, wider charts, and total licensed users input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+See [.github/copilot-instructions.md](.github/copilot-instructions.md) for coding guidelines and project context.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -772,7 +772,7 @@ function App() {
             }
           } catch (err) {
             const msg = err instanceof Error ? err.message : 'Unknown error';
-            throw new Error(files.length > 1 ? `"${fileName}": ${msg}` : msg);
+            throw new Error(files.length > 1 ? `"${fileName}": ${msg}` : msg, { cause: err });
           }
         }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,7 +288,7 @@ const WeeklyTopModelsChart = React.memo(function WeeklyTopModelsChart({
       </div>
       <ChartContainer
         config={weeklyChartConfig}
-        className="h-[400px] w-full"
+        className="h-[600px] w-full"
       >
         <BarChart data={selectedWeekDailyData}>
           <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
@@ -420,7 +420,7 @@ const BehaviorScatterChart = React.memo(function BehaviorScatterChart({
         })}
       </div>
 
-      <div className="h-[460px] w-full">
+      <div className="h-[600px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart margin={{ top: 16, right: 24, left: 8, bottom: 8 }}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
@@ -514,6 +514,7 @@ function App() {
   const [dailyOveruserData, setDailyOveruserData] = useState<DailyOveruserData[]>([]);
   const [modelSortColumn, setModelSortColumn] = useState<keyof ModelUsageSummary | null>(null);
   const [modelSortDirection, setModelSortDirection] = useState<'asc' | 'desc'>('desc');
+  const [totalLicensedUsers, setTotalLicensedUsers] = useState<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   
   // Recalculate users exceeding quota when plan selection changes
@@ -603,9 +604,6 @@ function App() {
     const expectedCost = getExpectedExcessCost(filteredData, selectedPlan);
     setExpectedExcessCost(expectedCost);
 
-    // Get daily overuser percentage data
-    setDailyOveruserData(getDailyOveruserPercentage(filteredData));
-    
     // Reset selected power user when month changes
     setSelectedPowerUser(null);
     
@@ -669,11 +667,19 @@ function App() {
       // Get the last date available in the display data
       const lastDate = getLastDateFromData(displayData);
       setLastDateAvailable(lastDate);
-
-      // Get daily overuser percentage data
-      setDailyOveruserData(getDailyOveruserPercentage(displayData));
     }
   }, [displayData, selectedPlan]);
+
+  // Recompute daily overuser data whenever the display data or total licensed users override changes
+  useEffect(() => {
+    if (displayData && displayData.length > 0) {
+      setDailyOveruserData(
+        getDailyOveruserPercentage(displayData, totalLicensedUsers ?? undefined)
+      );
+    } else {
+      setDailyOveruserData([]);
+    }
+  }, [displayData, totalLicensedUsers]);
 
   const handlePowerUserSelect = useCallback((userName: string | null) => {
     setSelectedPowerUser(userName);
@@ -705,122 +711,116 @@ function App() {
     return getUniqueModelsFromBreakdown(breakdown);
   }, [getFilteredPowerUserBreakdown]);
 
-  const processFile = useCallback((file: File) => {
-    if (!file) return;
-    
-    // Add basic file validation
-    if (!file.type.includes('text') && !file.type.includes('csv') && !file.name.endsWith('.csv')) {
-      toast.error("Please upload a valid CSV or text file.");
-      return;
-    }
-    
+  const resetDataState = useCallback(() => {
+    setData(null);
+    setRawData(null);
+    setAvailableMonths([]);
+    setSelectedMonth('');
+    setAggregatedData([]);
+    setModelSummary([]);
+    setDailyModelData([]);
+    setPowerUserSummary(null);
+    setPowerUserDailyBreakdown([]);
+    setSelectedPowerUser(null);
+    setUsersExceedingQuota(0);
+    setLastDateAvailable(null);
+    setDailyOveruserData([]);
+  }, []);
+
+  const processFiles = useCallback((files: File[]) => {
+    if (files.length === 0) return;
+
     setIsProcessing(true);
-    
-    const reader = new FileReader();
-    
-    reader.onerror = () => {
-      setIsProcessing(false);
-      toast.error("Failed to read the file. The file may be corrupted or unreadable.");
-    };
-    
-    reader.onload = (e) => {
-      try {
-        const csvContent = e.target?.result as string;
-        if (!csvContent) throw new Error("Failed to read file content");
-        
-        // Check if the content looks like text (not binary)
-        if (csvContent.includes('\0')) {
-          throw new Error("File appears to be binary. Please upload a text-based CSV file.");
-        }
-        
-        // Check for minimum content
-        if (csvContent.trim().length === 0) {
-          throw new Error("File is empty. Please upload a CSV file with data.");
-        }
-        
-        const parsedData = parseCSV(csvContent);
-        
-        // Store raw unfiltered data
-        setRawData(parsedData);
-        
-        // Extract available months (current and previous month)
-        const months = getAvailableMonths(parsedData);
-        setAvailableMonths(months);
-        
-        // Auto-select current month if available, otherwise select the first (most recent) month
-        const defaultMonth = months.find(m => m.isCurrentMonth)?.value || months[0]?.value || '';
-        setSelectedMonth(defaultMonth);
-        
-        // Process data for the default selected month
-        if (defaultMonth) {
-          processDataForMonth(parsedData, defaultMonth);
-        }
-        
-        setIsProcessing(false);
-        toast.success(`Loaded ${parsedData.length.toLocaleString()} records successfully`);
-      } catch (error) {
-        // Provide user-friendly error messages  
-        let errorMessage = "Failed to parse CSV file. Please check the format.";
-        
-        if (error instanceof Error) {
-          // Log detailed error information to console for debugging
-          console.error("CSV parsing error details:", error);
-          
-          // Provide more specific error messages based on the error type
-          if (error.message.includes("missing required columns")) {
-            errorMessage = "Invalid CSV format: " + error.message;
-          } else if (error.message.includes("Invalid timestamp")) {
-            errorMessage = "Invalid data format: " + error.message;
-          } else if (error.message.includes("Invalid requests used")) {
-            errorMessage = "Invalid data format: " + error.message;
-          } else if (error.message.includes("Invalid exceeds quota")) {
-            errorMessage = "Invalid data format: " + error.message;
-          } else if (error.message.includes("Invalid CSV row format")) {
-            errorMessage = "Invalid CSV structure: " + error.message;
-          } else if (error.message.includes("binary")) {
-            errorMessage = error.message;
-          } else if (error.message.includes("empty")) {
-            errorMessage = error.message;
-          } else if (error.message.includes("header")) {
-            errorMessage = "Invalid CSV format: " + error.message;
-          } else {
-            errorMessage = error.message;
+
+    const readFile = (file: File): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onerror = () => reject(new Error(`Failed to read "${file.name}". The file may be corrupted.`));
+        reader.onload = (e) => {
+          const content = e.target?.result as string;
+          if (!content) reject(new Error(`Failed to read "${file.name}"`));
+          else resolve(content);
+        };
+        reader.readAsText(file);
+      });
+
+    Promise.all(files.map(readFile))
+      .then((contents) => {
+        const allData: CopilotUsageData[] = [];
+        const seenKeys = new Set<string>();
+
+        for (let i = 0; i < contents.length; i++) {
+          const csvContent = contents[i];
+          const fileName = files[i].name;
+
+          try {
+            if (csvContent.includes('\0')) {
+              throw new Error(`File appears to be binary. Please upload a text-based CSV file.`);
+            }
+            if (csvContent.trim().length === 0) {
+              throw new Error(`File is empty. Please upload a CSV file with data.`);
+            }
+
+            const parsedData = parseCSV(csvContent);
+
+            for (const record of parsedData) {
+              const key = `${record.timestamp.toISOString()}_${record.user}_${record.model}_${record.requestsUsed}`;
+              if (!seenKeys.has(key)) {
+                seenKeys.add(key);
+                allData.push(record);
+              }
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Unknown error';
+            throw new Error(files.length > 1 ? `"${fileName}": ${msg}` : msg);
           }
         }
-        
+
+        if (allData.length === 0) {
+          throw new Error('No records found in the uploaded files.');
+        }
+
+        setRawData(allData);
+
+        const months = getAvailableMonths(allData);
+        setAvailableMonths(months);
+
+        const defaultMonth = months.find(m => m.isCurrentMonth)?.value || months[0]?.value || '';
+        setSelectedMonth(defaultMonth);
+
+        if (defaultMonth) {
+          processDataForMonth(allData, defaultMonth);
+        }
+
         setIsProcessing(false);
-        toast.error(errorMessage);
-        setData(null);
-        setRawData(null);
-        setAvailableMonths([]);
-        setSelectedMonth('');
-        setAggregatedData([]);
-        setModelSummary([]);
-        setDailyModelData([]);
-        setPowerUserSummary(null);
-        setPowerUserDailyBreakdown([]);
-        setSelectedPowerUser(null);
-        setUsersExceedingQuota(0);
-        setLastDateAvailable(null);
-        setDailyOveruserData([]);
-      }
-    };
-    
-    reader.readAsText(file);
-  }, [processDataForMonth]);
-  
+        const label = files.length > 1
+          ? `${files.length} files (${allData.length.toLocaleString()} records)`
+          : `${allData.length.toLocaleString()} records`;
+        toast.success(`Loaded ${label} successfully`);
+      })
+      .catch((error) => {
+        console.error('CSV parsing error:', error);
+        setIsProcessing(false);
+        toast.error(error instanceof Error ? error.message : 'Failed to process the uploaded file(s).');
+        resetDataState();
+      });
+  }, [processDataForMonth, resetDataState]);
+
   const handleFileUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     if (isProcessing) return;
-    
-    const file = event.target.files?.[0];
-    if (file) {
-      processFile(file);
+    const files = event.target.files;
+    if (files && files.length > 0) {
+      const validFiles = Array.from(files).filter(
+        f => f.type.includes('text') || f.type.includes('csv') || f.name.endsWith('.csv')
+      );
+      if (validFiles.length > 0) {
+        processFiles(validFiles);
+      } else {
+        toast.error('Please upload valid CSV files.');
+      }
     }
-    // Reset the input value to allow selecting the same file again
-    if (event.target) {
-      event.target.value = '';
-    }
-  }, [processFile, isProcessing]);
+    if (event.target) event.target.value = '';
+  }, [processFiles, isProcessing]);
   
   const handleButtonClick = () => {
     if (isProcessing) return;
@@ -849,14 +849,19 @@ function App() {
     
     const files = e.dataTransfer?.files;
     if (files && files.length > 0) {
-      const file = files[0];
-      if (file.type === "text/csv" || file.name.endsWith('.csv') || file.type.includes('text')) {
-        processFile(file);
-      } else {
-        toast.error("Please upload a CSV file. Supported formats: .csv files or text files with CSV content.");
+      const validFiles = Array.from(files).filter(
+        f => f.type === 'text/csv' || f.name.endsWith('.csv') || f.type.includes('text')
+      );
+      if (validFiles.length === 0) {
+        toast.error('Please upload CSV files. Supported formats: .csv files or text files with CSV content.');
+        return;
       }
+      if (validFiles.length < files.length) {
+        toast.warning(`${files.length - validFiles.length} non-CSV file(s) were skipped.`);
+      }
+      processFiles(validFiles);
     }
-  }, [processFile, isProcessing]);
+  }, [processFiles, isProcessing]);
   
   // Generate chart data grouped by date with total compliant and exceeding requests
   const chartData = useCallback(() => {
@@ -1114,7 +1119,7 @@ function App() {
   };
 
   return (
-    <div className="container max-w-7xl mx-auto py-8 px-4 min-h-screen">
+    <div className="container max-w-[1600px] mx-auto py-8 px-4 min-h-screen">
       <header className="mb-8">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">
@@ -1123,17 +1128,31 @@ function App() {
               GitHub Copilot Premium Requests Usage Analyzer
             </h1>
           </div>
-          <Button variant="outline" size="sm" asChild>
-            <a 
-              href="https://github.com/devops-actions/github-copilot-premium-reqs-usage" 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="flex items-center gap-2"
-            >
-              <GithubLogo size={16} />
-              Contribute
-            </a>
-          </Button>
+          <div className="flex items-center gap-2">
+            {data && data.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { resetDataState(); }}
+                disabled={isProcessing}
+                className="flex items-center gap-2"
+              >
+                <Upload size={14} />
+                Upload New Files
+              </Button>
+            )}
+            <Button variant="outline" size="sm" asChild>
+              <a 
+                href="https://github.com/devops-actions/github-copilot-premium-reqs-usage" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className="flex items-center gap-2"
+              >
+                <GithubLogo size={16} />
+                Contribute
+              </a>
+            </Button>
+          </div>
         </div>
       </header>
 
@@ -1185,14 +1204,14 @@ function App() {
             </div>
             
             <h2 className="text-xl font-medium mb-2">
-              {isProcessing ? "Processing CSV..." : "Upload CSV File"}
+              {isProcessing ? "Processing CSV..." : "Upload CSV Files"}
             </h2>
             <p className="text-muted-foreground mb-4 max-w-md mx-auto">
               {isProcessing 
-                ? "Please wait while we process your file..." 
+                ? "Please wait while we process your files..." 
                 : isDragging 
-                  ? "Drop your file here..." 
-                  : "Upload your GitHub Copilot premium requests usage CSV export to visualize the data. Drag and drop or select a file."}
+                  ? "Drop your files here..." 
+                  : "Upload your GitHub Copilot premium requests usage CSV exports to visualize the data. You can select multiple files at once — they will be merged automatically."}
             </p>
             
             <Button 
@@ -1200,13 +1219,14 @@ function App() {
               className="cursor-pointer"
               disabled={isProcessing}
             >
-              {isProcessing ? "Processing..." : "Select CSV File"}
+              {isProcessing ? "Processing..." : "Select CSV Files"}
             </Button>
             <input
               ref={fileInputRef}
               id="csv-upload"
               type="file"
               accept=".csv"
+              multiple
               onChange={handleFileUpload}
               className="hidden"
               disabled={isProcessing}
@@ -1395,6 +1415,34 @@ function App() {
                       <span className="text-lg font-bold">
                         {new Set(displayData.map(item => item.user)).size.toLocaleString()}
                       </span>
+                    </div>
+                    <div className="flex items-center gap-2" title="Total licensed seats — used as the denominator in the % Users with Overage chart. Leave empty to derive from active users in the data.">
+                      <span className="text-sm text-muted-foreground">Total Licensed Users:</span>
+                      <input
+                        type="number"
+                        min="1"
+                        placeholder="From data"
+                        value={totalLicensedUsers ?? ''}
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          if (val === '') {
+                            setTotalLicensedUsers(null);
+                          } else {
+                            const num = parseInt(val, 10);
+                            if (!isNaN(num) && num > 0) setTotalLicensedUsers(num);
+                          }
+                        }}
+                        className="w-24 h-8 text-sm font-bold border rounded px-2 bg-background text-foreground"
+                      />
+                      {totalLicensedUsers !== null && (
+                        <button
+                          onClick={() => setTotalLicensedUsers(null)}
+                          className="text-xs text-muted-foreground hover:text-foreground"
+                          title="Clear — revert to active users from data"
+                        >
+                          ✕
+                        </button>
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-muted-foreground">Models Used:</span>
@@ -1934,7 +1982,7 @@ function App() {
                   compliant: { color: "#10b981" }, // green
                   exceeding: { color: "#ef4444" }, // red
                 }} 
-                className="h-[400px] w-full"
+                className="h-[600px] w-full"
               >
                 <LineChart data={chartData()}>
                   <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
@@ -2027,7 +2075,7 @@ function App() {
                 <div className="bg-card p-4 rounded-lg border mb-8">
                   <ChartContainer
                     config={{ percentage: { color: "#f97316" } }}
-                    className="h-[300px] w-full"
+                    className="h-[400px] w-full"
                   >
                     <BarChart data={dailyOveruserData}>
                       <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
@@ -2052,7 +2100,7 @@ function App() {
                                 <div className="grid grid-cols-2 gap-x-4 gap-y-1">
                                   <span>Cumulative users with overage:</span>
                                   <span className="text-right font-medium">{d?.overusers.toLocaleString()}</span>
-                                  <span>Cumulative unique users:</span>
+                                  <span>{totalLicensedUsers !== null ? 'Total licensed users:' : 'Cumulative unique users:'}</span>
                                   <span className="text-right font-medium">{d?.totalUsers.toLocaleString()}</span>
                                   <span>Percentage:</span>
                                   <span className="text-right font-medium text-orange-500">
@@ -2100,7 +2148,7 @@ function App() {
                   acc[model] = { color };
                   return acc;
                 }, {} as Record<string, { color: string }>)}
-                className="h-[500px] w-full"
+                className="h-[700px] w-full"
               >
                 <BarChart data={allModelsChartData()}>
                   <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
@@ -2178,7 +2226,7 @@ function App() {
                   acc[model] = { color };
                   return acc;
                 }, {} as Record<string, { color: string }>)}
-                className="h-[500px] w-full"
+                className="h-[700px] w-full"
               >
                 <BarChart data={barChartData()}>
                   <CartesianGrid strokeDasharray="3 3" opacity={0.2} />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -300,9 +300,13 @@ export interface DailyOveruserData {
 /**
  * For each day, compute the cumulative count of unique users who have ever had an
  * exceeding request up to and including that day, as a percentage of all unique
- * users seen up to and including that day.
+ * users seen up to and including that day (or a fixed total when provided).
+ *
+ * @param fixedTotalUsers - When provided, use this as the denominator for the
+ *   percentage instead of the count of unique users seen in the data. This lets
+ *   callers express overages as a share of all licensed seats, not just active users.
  */
-export function getDailyOveruserPercentage(data: CopilotUsageData[]): DailyOveruserData[] {
+export function getDailyOveruserPercentage(data: CopilotUsageData[], fixedTotalUsers?: number): DailyOveruserData[] {
   const dailyData: Record<string, { totalUsers: Set<string>; overusers: Set<string> }> = {};
 
   data.forEach(item => {
@@ -324,11 +328,12 @@ export function getDailyOveruserPercentage(data: CopilotUsageData[]): DailyOveru
     const { totalUsers, overusers } = dailyData[date];
     totalUsers.forEach(u => cumulativeUsers.add(u));
     overusers.forEach(u => cumulativeOverusers.add(u));
+    const denominator = fixedTotalUsers ?? cumulativeUsers.size;
     return {
       date,
-      totalUsers: cumulativeUsers.size,
+      totalUsers: fixedTotalUsers ?? cumulativeUsers.size,
       overusers: cumulativeOverusers.size,
-      percentage: cumulativeUsers.size > 0 ? (cumulativeOverusers.size / cumulativeUsers.size) * 100 : 0,
+      percentage: denominator > 0 ? (cumulativeOverusers.size / denominator) * 100 : 0,
     };
   });
 }

--- a/src/test/spinner-functionality.test.tsx
+++ b/src/test/spinner-functionality.test.tsx
@@ -7,8 +7,8 @@ describe('Spinner Functionality', () => {
     render(<App />);
     
     // Check that the component renders without crashing
-    expect(screen.getByText('Upload CSV File')).toBeInTheDocument();
-    expect(screen.getByText('Select CSV File')).toBeInTheDocument();
+    expect(screen.getByText('Upload CSV Files')).toBeInTheDocument();
+    expect(screen.getByText('Select CSV Files')).toBeInTheDocument();
     
     // The spinner functionality is integrated into the existing upload component
     // The actual spinner will only show during file processing which requires


### PR DESCRIPTION
## Summary

This PR adds three quality-of-life improvements to the analyzer:

### 1. Multi-file CSV upload
- The file picker now accepts **multiple CSV files at once** (and drag-and-drop too)
- Files are read in parallel and merged automatically, with deduplication by `(timestamp, user, model, requestsUsed)` to avoid double-counting if the same file is selected twice
- Individual file parse errors include the filename for easy debugging
- "Upload New Files" button is shown in the header when data is already loaded, so the user can restart without a page refresh

### 2. Wider / taller charts
- Page container widened from `max-w-7xl` (1280px) to `max-w-[1600px]`
- Chart heights increased:
  - Daily Usage Overview line chart: 400 → 600px
  - Weekly Top Models bar chart: 400 → 600px
  - User Behavior scatter: 460 → 600px
  - % Users with Overage bar: 300 → 400px
  - All Models / Top 5 Models bar charts: 500 → 700px

### 3. Total Licensed Users input
- A **"Total Licensed Users"** number input appears in the stats summary card, next to "Unique Users"
- When set, it overrides the denominator of the **% Users with Overage (Cumulative)** chart — so the percentage reflects overages against all licensed seats, not just the active users visible in the CSV
- The chart tooltip label updates accordingly ("Total licensed users" vs "Cumulative unique users")
- Clear button (✕) resets to the data-derived count
- `getDailyOveruserPercentage` accepts an optional `fixedTotalUsers` parameter so this logic is cleanly separated from UI state

### Files changed
- `src/App.tsx` — all UI changes
- `src/lib/utils.ts` — `getDailyOveruserPercentage` signature update
- `src/test/spinner-functionality.test.tsx` — updated text assertions to match new "Upload CSV Files" wording
- `AGENTS.md` — added, pointing to `.github/copilot-instructions.md`