### PR TITLE
feat: Add AIC cost chart (aic_quantity & aic_gross_amount)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/utils";
 import { MonthSelector } from "@/components/MonthSelector";
 import { UserSearch } from "@/components/UserSearch";
+import { AICCostChart } from "@/components/AICCostChart";
 
 const MODEL_COLORS = [
   "#8B5CF6", // Purple
@@ -2157,6 +2158,25 @@ function App() {
                 </div>
               </>
             )}
+
+            {/* Bar Chart - Requests per Model per Day (All Models) */}
+            <div className="flex justify-between items-center mb-2 mt-8">
+              <h2 className="text-2xl font-semibold">
+                Estimated Cost &amp; AI Credits Usage
+                {selectedSearchUser && (
+                  <span className="ml-2 text-lg font-medium text-blue-600">
+                    - {displayUser(selectedSearchUser)}
+                  </span>
+                )}
+              </h2>
+              {lastDateAvailable && (
+                <div className="text-sm text-muted-foreground">
+                  Data available through: <span className="font-medium">{lastDateAvailable}</span>
+                </div>
+              )}
+            </div>
+            <Separator className="mb-6" />
+            <AICCostChart data={displayData} />
 
             {/* Bar Chart - Requests per Model per Day (All Models) */}
             <div className="flex justify-between items-center mb-2 mt-8">

--- a/src/components/AICCostChart.tsx
+++ b/src/components/AICCostChart.tsx
@@ -1,0 +1,191 @@
+import React, { useMemo, useState } from "react";
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Button } from "@/components/ui/button";
+import {
+  AICGroupBy,
+  CopilotUsageData,
+  getAICData,
+  getAICDataStatus,
+} from "@/lib/utils";
+
+type AICCostChartProps = {
+  data: CopilotUsageData[];
+};
+
+export const AICCostChart = React.memo(function AICCostChart({ data }: AICCostChartProps) {
+  const [groupBy, setGroupBy] = useState<AICGroupBy>("day");
+
+  const status = useMemo(() => getAICDataStatus(data), [data]);
+  const chartData = useMemo(() => getAICData(data, groupBy), [data, groupBy]);
+
+  const hasAny = status.hasQuantityField || status.hasAmountField;
+
+  if (!hasAny) {
+    return (
+      <div className="bg-card p-8 rounded-lg border text-center">
+        <p className="text-muted-foreground text-sm">
+          The uploaded data does not contain AI Credits fields (
+          <code className="text-xs bg-muted px-1 py-0.5 rounded">aic_quantity</code> or{" "}
+          <code className="text-xs bg-muted px-1 py-0.5 rounded">aic_gross_amount</code>).
+          These fields are available in newer GitHub Copilot usage exports.
+        </p>
+      </div>
+    );
+  }
+
+  if (!status.hasQuantityData && !status.hasAmountData) {
+    return (
+      <div className="bg-card p-8 rounded-lg border text-center">
+        <p className="text-muted-foreground text-sm">
+          The AIC fields are present in the data but contain no non-zero values for the selected
+          period.
+        </p>
+      </div>
+    );
+  }
+
+  const GROUP_LABELS: Record<AICGroupBy, string> = {
+    day: "Day",
+    week: "Week",
+    month: "Month",
+  };
+
+  return (
+    <div className="bg-card p-4 rounded-lg border mb-8">
+      {/* Zoom controls */}
+      <div className="flex gap-2 mb-4">
+        {(["day", "week", "month"] as AICGroupBy[]).map((g) => (
+          <Button
+            key={g}
+            variant={groupBy === g ? "default" : "outline"}
+            size="sm"
+            onClick={() => setGroupBy(g)}
+          >
+            {GROUP_LABELS[g]}
+          </Button>
+        ))}
+      </div>
+
+      <ResponsiveContainer width="100%" height={400}>
+        <ComposedChart data={chartData} margin={{ top: 8, right: 60, left: 8, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis
+            dataKey="label"
+            tick={{ fill: "var(--foreground)", fontSize: 12 }}
+            tickLine={{ stroke: "var(--border)" }}
+          />
+
+          {/* Left axis: AI credits quantity */}
+          {status.hasQuantityField && (
+            <YAxis
+              yAxisId="left"
+              orientation="left"
+              tick={{ fill: "var(--foreground)" }}
+              tickLine={{ stroke: "var(--border)" }}
+              tickFormatter={(v) => v.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+              label={{
+                value: "AI Credits",
+                angle: -90,
+                position: "insideLeft",
+                style: { fill: "var(--foreground)", fontSize: 12 },
+                offset: 8,
+              }}
+            />
+          )}
+
+          {/* Right axis: estimated cost (USD) */}
+          {status.hasAmountField && (
+            <YAxis
+              yAxisId="right"
+              orientation="right"
+              tick={{ fill: "var(--foreground)" }}
+              tickLine={{ stroke: "var(--border)" }}
+              tickFormatter={(v) =>
+                `$${v.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}`
+              }
+              label={{
+                value: "Est. Cost (USD)",
+                angle: 90,
+                position: "insideRight",
+                style: { fill: "var(--foreground)", fontSize: 12 },
+                offset: 16,
+              }}
+            />
+          )}
+
+          <Tooltip
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              return (
+                <div className="border rounded-lg bg-background shadow-lg p-3 text-xs">
+                  <div className="font-medium mb-2">{label}</div>
+                  <div className="space-y-1.5">
+                    {payload.map((entry) => {
+                      const isAmount = entry.dataKey === "aicGrossAmount";
+                      const val = Number(entry.value);
+                      const formatted = isAmount
+                        ? `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`
+                        : val.toLocaleString(undefined, { maximumFractionDigits: 4, minimumFractionDigits: 0 });
+                      return (
+                        <div key={String(entry.dataKey)} className="flex justify-between items-center gap-4">
+                          <div className="flex items-center gap-1.5">
+                            <div
+                              className="w-2 h-2 rounded-full"
+                              style={{ backgroundColor: entry.color as string }}
+                            />
+                            <span>{entry.name}:</span>
+                          </div>
+                          <div className="font-medium">{formatted}</div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            }}
+          />
+          <Legend />
+
+          {/* Bar for estimated cost (rendered first so the line sits on top) */}
+          {status.hasAmountField && (
+            <Bar
+              yAxisId="right"
+              dataKey="aicGrossAmount"
+              name="Est. Cost (USD)"
+              fill="#f97316"
+              opacity={0.8}
+              radius={[3, 3, 0, 0]}
+            />
+          )}
+
+          {/* Line for AI credits quantity */}
+          {status.hasQuantityField && (
+            <Line
+              yAxisId="left"
+              type="monotone"
+              dataKey="aicQuantity"
+              name="AI Credits"
+              stroke="#3b82f6"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          )}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,6 +15,8 @@ export interface CopilotUsageData {
   requestsUsed: number;
   exceedsQuota: boolean;
   totalMonthlyQuota: string;
+  aicQuantity?: number;     // aic_quantity: number of AI credits consumed
+  aicGrossAmount?: number;  // aic_gross_amount: estimated cost in USD under usage-based billing
 }
 
 export interface AggregatedData {
@@ -49,6 +51,9 @@ export function parseCSV(csv: string): CopilotUsageData[] {
     'quantity': 'requestsUsed',
     'exceeds_quota': 'exceedsQuota',
     'total_monthly_quota': 'totalMonthlyQuota',
+    // AIC fields (optional)
+    'aic_quantity': 'aicQuantity',
+    'aic_gross_amount': 'aicGrossAmount',
     // Backward compatibility (old headers)
     'timestamp': 'timestamp',
     'user': 'user',
@@ -112,6 +117,23 @@ export function parseCSV(csv: string): CopilotUsageData[] {
       return val.trim();
     };
 
+    const getOptionalValue = (field: keyof CopilotUsageData): string | undefined => {
+      const idx = fieldToIndex[field];
+      if (idx === undefined) return undefined;
+      let val = matches[idx] || '';
+      val = val.endsWith(',') ? val.slice(0, -1) : val;
+      val = val.replace(/^"(.*)"$/, '$1');
+      const trimmed = val.trim();
+      return trimmed === '' ? undefined : trimmed;
+    };
+
+    const parseOptionalNumber = (value: string | undefined): number | undefined => {
+      if (value === undefined) return undefined;
+      const normalized = value.replace(/,/g, '');
+      const parsed = Number(normalized);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    };
+
     // Validate and parse fields
     const timestampStr = getValue('timestamp');
     const timestamp = new Date(timestampStr);
@@ -133,6 +155,8 @@ export function parseCSV(csv: string): CopilotUsageData[] {
     }
 
     const totalMonthlyQuota = getValue('totalMonthlyQuota');
+    const aicQuantity = parseOptionalNumber(getOptionalValue('aicQuantity'));
+    const aicGrossAmount = parseOptionalNumber(getOptionalValue('aicGrossAmount'));
 
     return {
       timestamp,
@@ -141,6 +165,8 @@ export function parseCSV(csv: string): CopilotUsageData[] {
       requestsUsed,
       exceedsQuota: exceedsQuotaValue === 'true',
       totalMonthlyQuota,
+      ...(aicQuantity !== undefined ? { aicQuantity } : {}),
+      ...(aicGrossAmount !== undefined ? { aicGrossAmount } : {}),
     };
   }).filter(Boolean) as CopilotUsageData[];
 }
@@ -1344,3 +1370,98 @@ export function getUserAnalysisData(data: CopilotUsageData[], username: string):
     lastActivityDate
   };
 }
+
+// ─── AIC (AI Credits) cost data ───────────────────────────────────────────────
+
+export type AICGroupBy = 'day' | 'week' | 'month';
+
+export interface AICDataPoint {
+  label: string;   // display label for the X-axis
+  period: string;  // sort key (YYYY-MM-DD for day, week-start date for week, YYYY-MM for month)
+  aicQuantity: number;
+  aicGrossAmount: number;
+}
+
+export interface AICDataStatus {
+  /** Whether ANY record has the aic_quantity field present (even if zero). */
+  hasQuantityField: boolean;
+  /** Whether ANY record has the aic_gross_amount field present (even if zero). */
+  hasAmountField: boolean;
+  /** Whether there is at least one non-zero aic_quantity value. */
+  hasQuantityData: boolean;
+  /** Whether there is at least one non-zero aic_gross_amount value. */
+  hasAmountData: boolean;
+}
+
+/**
+ * Returns information about whether AIC fields are present and have meaningful data.
+ */
+export function getAICDataStatus(data: CopilotUsageData[]): AICDataStatus {
+  let hasQuantityField = false;
+  let hasAmountField = false;
+  let hasQuantityData = false;
+  let hasAmountData = false;
+
+  for (const item of data) {
+    if (item.aicQuantity !== undefined) {
+      hasQuantityField = true;
+      if (item.aicQuantity > 0) hasQuantityData = true;
+    }
+    if (item.aicGrossAmount !== undefined) {
+      hasAmountField = true;
+      if (item.aicGrossAmount > 0) hasAmountData = true;
+    }
+    if (hasQuantityData && hasAmountData) break;
+  }
+
+  return { hasQuantityField, hasAmountField, hasQuantityData, hasAmountData };
+}
+
+/**
+ * Aggregates AIC quantity and gross amount by day, ISO week, or calendar month.
+ * UTC-based to be consistent with all other date handling in the app.
+ */
+export function getAICData(data: CopilotUsageData[], groupBy: AICGroupBy = 'day'): AICDataPoint[] {
+  if (!data.length) return [];
+
+  const grouped: Record<string, AICDataPoint> = {};
+
+  data.forEach(item => {
+    const dateStr = item.timestamp.toISOString().split('T')[0]; // YYYY-MM-DD (UTC)
+    let period: string;
+    let label: string;
+
+    if (groupBy === 'day') {
+      period = dateStr;
+      label = dateStr;
+    } else if (groupBy === 'week') {
+      // Compute the Monday of the ISO week in UTC (matches WeeklyTopModelsChart)
+      const d = new Date(dateStr + 'T00:00:00Z');
+      const day = d.getUTCDay(); // 0 = Sunday
+      const diffToMon = day === 0 ? -6 : 1 - day;
+      const mon = new Date(d);
+      mon.setUTCDate(d.getUTCDate() + diffToMon);
+      period = mon.toISOString().split('T')[0];
+      label = mon.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+    } else {
+      // Month: YYYY-MM
+      period = dateStr.slice(0, 7);
+      const d = new Date(dateStr + 'T00:00:00Z');
+      label = d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', timeZone: 'UTC' });
+    }
+
+    if (!grouped[period]) {
+      grouped[period] = { label, period, aicQuantity: 0, aicGrossAmount: 0 };
+    }
+
+    if (item.aicQuantity !== undefined) {
+      grouped[period].aicQuantity += item.aicQuantity;
+    }
+    if (item.aicGrossAmount !== undefined) {
+      grouped[period].aicGrossAmount += item.aicGrossAmount;
+    }
+  });
+
+  return Object.values(grouped).sort((a, b) => a.period.localeCompare(b.period));
+}
+

--- a/src/test/aic-cost-data.test.ts
+++ b/src/test/aic-cost-data.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import { parseCSV, getAICData, getAICDataStatus } from '@/lib/utils'
+
+const BASE_HEADERS = '"Timestamp","User","Model","Requests Used","Exceeds Monthly Quota","Total Monthly Quota"'
+const BASE_ROW = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited"'
+
+describe('AIC field parsing', () => {
+  it('should parse records without AIC fields without error', () => {
+    const csv = `${BASE_HEADERS}\n${BASE_ROW}`
+    const result = parseCSV(csv)
+    expect(result).toHaveLength(1)
+    expect(result[0].aicQuantity).toBeUndefined()
+    expect(result[0].aicGrossAmount).toBeUndefined()
+  })
+
+  it('should not include AIC keys in records when columns are absent', () => {
+    const csv = `${BASE_HEADERS}\n${BASE_ROW}`
+    const result = parseCSV(csv)
+    expect('aicQuantity' in result[0]).toBe(false)
+    expect('aicGrossAmount' in result[0]).toBe(false)
+  })
+
+  it('should parse aic_quantity and aic_gross_amount when present', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"'
+    const result = parseCSV(`${headers}\n${row}`)
+    expect(result[0].aicQuantity).toBe(5)
+    expect(result[0].aicGrossAmount).toBeCloseTo(0.0025)
+  })
+
+  it('should be case-insensitive for AIC headers', () => {
+    const headers = `${BASE_HEADERS},"AIC_QUANTITY","AIC_GROSS_AMOUNT"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","10","0.005"'
+    const result = parseCSV(`${headers}\n${row}`)
+    expect(result[0].aicQuantity).toBe(10)
+    expect(result[0].aicGrossAmount).toBeCloseTo(0.005)
+  })
+
+  it('should omit AIC fields when cells are empty', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","",""'
+    const result = parseCSV(`${headers}\n${row}`)
+    expect('aicQuantity' in result[0]).toBe(false)
+    expect('aicGrossAmount' in result[0]).toBe(false)
+  })
+
+  it('should omit AIC fields when cells contain non-numeric values', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","abc","$bad"'
+    const result = parseCSV(`${headers}\n${row}`)
+    expect('aicQuantity' in result[0]).toBe(false)
+    expect('aicGrossAmount' in result[0]).toBe(false)
+  })
+
+  it('should parse zero values correctly', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","0","0"'
+    const result = parseCSV(`${headers}\n${row}`)
+    expect(result[0].aicQuantity).toBe(0)
+    expect(result[0].aicGrossAmount).toBe(0)
+  })
+
+  it('should parse mixed rows where some have AIC data and some do not', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const rows = [
+      '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"',
+      '"2025-06-11T06:00:00.0000000Z","bob","gpt-4.1","1","False","Unlimited","",""',
+    ]
+    const result = parseCSV(`${headers}\n${rows.join('\n')}`)
+    expect(result[0].aicQuantity).toBe(5)
+    expect('aicQuantity' in result[1]).toBe(false)
+  })
+})
+
+describe('getAICDataStatus', () => {
+  it('should return all false when no AIC fields present', () => {
+    const csv = `${BASE_HEADERS}\n${BASE_ROW}`
+    const data = parseCSV(csv)
+    const status = getAICDataStatus(data)
+    expect(status.hasQuantityField).toBe(false)
+    expect(status.hasAmountField).toBe(false)
+    expect(status.hasQuantityData).toBe(false)
+    expect(status.hasAmountData).toBe(false)
+  })
+
+  it('should detect fields even when all values are zero', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","0","0"'
+    const data = parseCSV(`${headers}\n${row}`)
+    const status = getAICDataStatus(data)
+    expect(status.hasQuantityField).toBe(true)
+    expect(status.hasAmountField).toBe(true)
+    expect(status.hasQuantityData).toBe(false) // zero is not > 0
+    expect(status.hasAmountData).toBe(false)
+  })
+
+  it('should detect non-zero data correctly', () => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const row = '"2025-06-11T05:13:27.8766440Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"'
+    const data = parseCSV(`${headers}\n${row}`)
+    const status = getAICDataStatus(data)
+    expect(status.hasQuantityField).toBe(true)
+    expect(status.hasAmountField).toBe(true)
+    expect(status.hasQuantityData).toBe(true)
+    expect(status.hasAmountData).toBe(true)
+  })
+})
+
+describe('getAICData aggregation', () => {
+  const makeCSV = (rows: string[]) => {
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    return `${headers}\n${rows.join('\n')}`
+  }
+
+  it('should return empty array for empty data', () => {
+    expect(getAICData([], 'day')).toEqual([])
+  })
+
+  it('should aggregate by day correctly', () => {
+    const csv = makeCSV([
+      '"2025-06-11T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"',
+      '"2025-06-11T06:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","3","0.0015"',
+      '"2025-06-12T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","4","0.002"',
+    ])
+    const data = parseCSV(csv)
+    const result = getAICData(data, 'day')
+    expect(result).toHaveLength(2)
+    expect(result[0].period).toBe('2025-06-11')
+    expect(result[0].aicQuantity).toBe(8)
+    expect(result[0].aicGrossAmount).toBeCloseTo(0.004)
+    expect(result[1].period).toBe('2025-06-12')
+    expect(result[1].aicQuantity).toBe(4)
+  })
+
+  it('should aggregate by week correctly', () => {
+    // June 9, 2025 is a Monday; June 11 is a Wednesday of the same week
+    const csv = makeCSV([
+      '"2025-06-09T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"',
+      '"2025-06-11T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","3","0.0015"',
+      '"2025-06-16T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","4","0.002"',
+    ])
+    const data = parseCSV(csv)
+    const result = getAICData(data, 'week')
+    expect(result).toHaveLength(2)
+    // First week starts on June 9 (Monday)
+    expect(result[0].period).toBe('2025-06-09')
+    expect(result[0].aicQuantity).toBe(8)
+    // Second week starts on June 16 (Monday)
+    expect(result[1].period).toBe('2025-06-16')
+    expect(result[1].aicQuantity).toBe(4)
+  })
+
+  it('should aggregate by month correctly', () => {
+    const csv = makeCSV([
+      '"2025-06-11T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"',
+      '"2025-06-15T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","3","0.0015"',
+      '"2025-07-01T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","4","0.002"',
+    ])
+    const data = parseCSV(csv)
+    const result = getAICData(data, 'month')
+    expect(result).toHaveLength(2)
+    expect(result[0].period).toBe('2025-06')
+    expect(result[0].aicQuantity).toBe(8)
+    expect(result[1].period).toBe('2025-07')
+    expect(result[1].aicQuantity).toBe(4)
+  })
+
+  it('should handle records without AIC fields (contribute 0)', () => {
+    // Mix of records with and without AIC fields
+    const headers = `${BASE_HEADERS},"aic_quantity","aic_gross_amount"`
+    const rows = [
+      '"2025-06-11T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","5","0.0025"',
+      '"2025-06-11T06:00:00.0000000Z","bob","gpt-4.1","1","False","Unlimited","",""',
+    ]
+    const data = parseCSV(`${headers}\n${rows.join('\n')}`)
+    const result = getAICData(data, 'day')
+    expect(result).toHaveLength(1)
+    expect(result[0].aicQuantity).toBe(5) // Only alice's record contributes
+    expect(result[0].aicGrossAmount).toBeCloseTo(0.0025)
+  })
+
+  it('should sort results by period ascending', () => {
+    const csv = makeCSV([
+      '"2025-06-13T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","1","0.001"',
+      '"2025-06-11T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","2","0.002"',
+      '"2025-06-12T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","3","0.003"',
+    ])
+    const data = parseCSV(csv)
+    const result = getAICData(data, 'day')
+    expect(result.map(r => r.period)).toEqual(['2025-06-11', '2025-06-12', '2025-06-13'])
+  })
+
+  it('should use UTC-based week start (Monday) consistent with WeeklyTopModelsChart', () => {
+    // Saturday June 14, 2025 should belong to the week starting Monday June 9, 2025
+    // Sunday June 15, 2025 should belong to the week starting Monday June 9, 2025 (ISO Sun = end of previous week)
+    // Monday June 16, 2025 should start a new week
+    const csv = makeCSV([
+      '"2025-06-14T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","1","0.001"', // Sat - week of Jun 9
+      '"2025-06-15T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","2","0.002"', // Sun - week of Jun 9
+      '"2025-06-16T05:00:00.0000000Z","alice","gpt-4.1","1","False","Unlimited","4","0.004"', // Mon - new week
+    ])
+    const data = parseCSV(csv)
+    const result = getAICData(data, 'week')
+    expect(result).toHaveLength(2)
+    expect(result[0].period).toBe('2025-06-09') // Mon Jun 9 is week start
+    expect(result[0].aicQuantity).toBe(3) // Sat + Sun
+    expect(result[1].period).toBe('2025-06-16') // Mon Jun 16 starts new week
+    expect(result[1].aicQuantity).toBe(4)
+  })
+})


### PR DESCRIPTION
## Summary

Adds support for two new optional CSV fields (`aic_quantity`, `aic_gross_amount`) and a new **Estimated Cost & AI Credits Usage** combined chart.

## Changes

### `src/lib/utils.ts`
- Added `aicQuantity?: number` and `aicGrossAmount?: number` to `CopilotUsageData` interface
- Updated `FIELD_MAP` with `aic_quantity` → `aicQuantity` and `aic_gross_amount` → `aicGrossAmount` mappings (case-insensitive, both fields optional)
- New `getOptionalValue` / `parseOptionalNumber` helpers in the row parser — fields are simply omitted when the column is absent or the cell is empty/non-numeric; no errors thrown
- New `getAICDataStatus()` — returns `hasQuantityField`, `hasAmountField`, `hasQuantityData`, `hasAmountData` to distinguish "column present" from "has non-zero values"
- New `getAICData(data, groupBy)` — aggregates by **day**, **week** (UTC Monday start, consistent with `WeeklyTopModelsChart`), or **month**

### `src/components/AICCostChart.tsx` (new)
- `ComposedChart` with a **bar** for estimated cost (right Y-axis, USD) and a **line** for AI credits (left Y-axis)
- **Day / Week / Month** zoom buttons
- Conditionally renders each axis/series only when the corresponding field is present
- Two distinct empty states:
  - Fields not in CSV at all → explains they're available in newer exports
  - Fields present but all zero → informs no data for the period

### `src/App.tsx`
- Imports `AICCostChart`
- Adds a new **"Estimated Cost & AI Credits Usage"** section between the "% Users with Overage Costs" chart and the "Requests per Model per Day" chart, passing `displayData` directly

### `src/test/aic-cost-data.test.ts` (new)
- 18 unit tests covering CSV parsing, optional field handling, `getAICDataStatus`, and `getAICData` day/week/month aggregation including UTC week-boundary edge cases

## Backward compatibility
- Old CSVs without the new columns parse exactly as before — existing tests unchanged (145/145 still pass; the 1 pre-existing failure in `user-analysis.test.ts` is a timezone bug unrelated to these changes)
- New fields are fully optional — all existing logic is unaffected