### PR TITLE
fix: preserve high-precision decimal digits in request count display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -322,13 +322,13 @@ const WeeklyTopModelsChart = React.memo(function WeeklyTopModelsChart({
                             />
                             <span>{entry.name}:</span>
                           </div>
-                          <div className="font-medium">{Number(entry.value).toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 0 })}</div>
+                          <div className="font-medium">{Number(entry.value).toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 })}</div>
                         </div>
                       ))}
                       {filtered.length > 1 && (
                         <div className="border-t pt-1 mt-1 flex justify-between font-semibold">
                           <span>Total:</span>
-                          <span>{total.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 0 })}</span>
+                          <span>{total.toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 })}</span>
                         </div>
                       )}
                     </div>
@@ -459,7 +459,7 @@ const BehaviorScatterChart = React.memo(function BehaviorScatterChart({
                         <div>Models Used: <span className="font-medium">{point.modelDiversity.toLocaleString()}</span></div>
                         <div>Top Model Share: <span className="font-medium">{point.topModelSharePct.toLocaleString(undefined, { maximumFractionDigits: 1 })}%</span></div>
                         <div>First Week Usage: <span className="font-medium">{(point.frontloadIndex * 100).toLocaleString(undefined, { maximumFractionDigits: 1 })}%</span></div>
-                        <div>Total Requests: <span className="font-medium">{point.totalRequests.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 0 })}</span></div>
+                        <div>Total Requests: <span className="font-medium">{point.totalRequests.toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 })}</span></div>
                       </div>
                     </div>
                   );
@@ -1431,7 +1431,7 @@ function App() {
                     <div className="flex items-center gap-2">
                       <span className="text-sm text-muted-foreground">Total Requests:</span>
                       <span className="text-lg font-bold">
-                        {displayData.reduce((sum, item) => sum + item.requestsUsed, 0).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                        {displayData.reduce((sum, item) => sum + item.requestsUsed, 0).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                       </span>
                     </div>
                     <div className="flex items-center gap-2">
@@ -1542,7 +1542,7 @@ function App() {
                                   <div className="flex justify-between items-center">
                                     <span className="text-sm text-muted-foreground">Total Requests:</span>
                                     <span className="font-bold">
-                                      {powerUserSummary.totalPowerUserRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                                      {powerUserSummary.totalPowerUserRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                                     </span>
                                   </div>
                                   <div className="flex justify-between items-center">
@@ -1566,7 +1566,7 @@ function App() {
                                       {powerUserSummary.powerUserModelSummary.map((item) => (
                                         <TableRow key={item.model}>
                                           <TableCell className="font-medium">{item.model}</TableCell>
-                                          <TableCell className="text-right">{item.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
+                                          <TableCell className="text-right">{item.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
                                         </TableRow>
                                       ))}
                                     </TableBody>
@@ -1605,7 +1605,7 @@ function App() {
                                               <div className="font-medium mb-2">{label}</div>
                                               <div className="flex items-center gap-2">
                                                 <div className="w-2 h-2 rounded-full bg-[#3b82f6]" />
-                                                <span>Requests: {Number(payload[0].value).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</span>
+                                                <span>Requests: {Number(payload[0].value).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</span>
                                               </div>
                                             </div>
                                           );
@@ -1708,7 +1708,7 @@ function App() {
                                         
                                         const formatNumber = (value) => 
                                           Number(value).toLocaleString(undefined, {
-                                            maximumFractionDigits: 2, 
+                                            maximumFractionDigits: 8, 
                                             minimumFractionDigits: 0
                                           });
 
@@ -1833,8 +1833,8 @@ function App() {
                                             <UserSquare className={`h-3 w-3 transition-all duration-200 group-hover:scale-110 opacity-60 group-hover:opacity-100 ${selectedPowerUser === user.user ? 'text-blue-700' : 'text-blue-500'}`} />
                                           </div>
                                         </TableCell>
-                                        <TableCell className="text-right">{user.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
-                                        <TableCell className="text-right">{user.exceedingRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
+                                        <TableCell className="text-right">{user.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
+                                        <TableCell className="text-right">{user.exceedingRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
                                         <TableCell className="text-right">{Object.keys(user.requestsByModel).length}</TableCell>
                                       </TableRow>
                                     ))}
@@ -1963,9 +1963,9 @@ function App() {
                       {sortedModelSummary.map((item) => (
                         <TableRow key={item.model}>
                           <TableCell className="font-medium">{item.model}</TableCell>
-                          <TableCell className="text-right">{item.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
-                          <TableCell className="text-right">{item.compliantRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
-                          <TableCell className="text-right">{item.exceedingRequests.toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</TableCell>
+                          <TableCell className="text-right">{item.totalRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
+                          <TableCell className="text-right">{item.compliantRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
+                          <TableCell className="text-right">{item.exceedingRequests.toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</TableCell>
                           <TableCell className="text-right">{item.multiplier}x</TableCell>
                         </TableRow>
                       ))}
@@ -1974,13 +1974,13 @@ function App() {
                       <TableRow className="bg-accent/20">
                         <TableCell className="font-medium">Total</TableCell>
                         <TableCell className="text-right font-medium">
-                          {modelSummary.reduce((sum, item) => sum + item.totalRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                          {modelSummary.reduce((sum, item) => sum + item.totalRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                         </TableCell>
                         <TableCell className="text-right font-medium">
-                          {modelSummary.reduce((sum, item) => sum + item.compliantRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                          {modelSummary.reduce((sum, item) => sum + item.compliantRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                         </TableCell>
                         <TableCell className="text-right font-medium">
-                          {modelSummary.reduce((sum, item) => sum + item.exceedingRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                          {modelSummary.reduce((sum, item) => sum + item.exceedingRequests, 0).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                         </TableCell>
                         <TableCell className="text-right">—</TableCell>
                       </TableRow>
@@ -2046,14 +2046,14 @@ function App() {
                                   <div className="w-2 h-2 rounded-full bg-[#10b981]" />
                                   <span>Compliant:</span>
                                 </div>
-                                <div className="text-right">{Number(compliant).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</div>
+                                <div className="text-right">{Number(compliant).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</div>
                                 <div className="flex items-center gap-1.5">
                                   <div className="w-2 h-2 rounded-full bg-[#ef4444]" />
                                   <span>Exceeding:</span>
                                 </div>
-                                <div className="text-right">{Number(exceeding).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</div>
+                                <div className="text-right">{Number(exceeding).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</div>
                                 <div className="font-medium">Total:</div>
-                                <div className="text-right font-medium">{Number(total).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</div>
+                                <div className="text-right font-medium">{Number(total).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</div>
                               </div>
                             </div>
                           </div>
@@ -2231,7 +2231,7 @@ function App() {
                                     />
                                     <span>{entry.name}:</span>
                                   </div>
-                                  <div className="font-medium">{Number(entry.value).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</div>
+                                  <div className="font-medium">{Number(entry.value).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</div>
                                 </div>
                               ))}
                             </div>
@@ -2309,7 +2309,7 @@ function App() {
                                     />
                                     <span>{entry.name}:</span>
                                   </div>
-                                  <div className="font-medium">{Number(entry.value).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}</div>
+                                  <div className="font-medium">{Number(entry.value).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}</div>
                                 </div>
                               ))}
                             </div>
@@ -2596,7 +2596,7 @@ function App() {
                       <div className="flex justify-between items-center">
                         <span className="text-sm text-muted-foreground">Total Requests:</span>
                         <span className="font-bold">
-                          {data.reduce((sum, item) => sum + item.requestsUsed, 0).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                          {data.reduce((sum, item) => sum + item.requestsUsed, 0).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                         </span>
                       </div>
                       <div className="flex justify-between items-center">
@@ -2666,7 +2666,7 @@ function App() {
                       <div className="flex justify-between items-center">
                         <span className="text-sm text-muted-foreground">Exceeding Requests:</span>
                         <span className="font-bold text-red-600">
-                          {getTotalRequestsForUsersExceedingQuota(data, selectedPlan).toLocaleString(undefined, {maximumFractionDigits: 2, minimumFractionDigits: 0})}
+                          {getTotalRequestsForUsersExceedingQuota(data, selectedPlan).toLocaleString(undefined, {maximumFractionDigits: 8, minimumFractionDigits: 0})}
                         </span>
                       </div>
                       <div className="flex justify-between items-center">

--- a/src/components/AICCostChart.tsx
+++ b/src/components/AICCostChart.tsx
@@ -138,7 +138,7 @@ export const AICCostChart = React.memo(function AICCostChart({ data }: AICCostCh
                       const val = Number(entry.value);
                       const formatted = isAmount
                         ? `$${val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`
-                        : val.toLocaleString(undefined, { maximumFractionDigits: 4, minimumFractionDigits: 0 });
+                        : val.toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 });
                       return (
                         <div key={String(entry.dataKey)} className="flex justify-between items-center gap-4">
                           <div className="flex items-center gap-1.5">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,6 +8,17 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * Format a request count value with up to 8 decimal places (no trailing zeros).
+ * Handles high-precision values like 107.03398500000002 correctly.
+ */
+export function formatRequestCount(value: number): string {
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: 8,
+    minimumFractionDigits: 0,
+  });
+}
+
 export interface CopilotUsageData {
   timestamp: Date;
   user: string;

--- a/src/test/high-precision-values.test.ts
+++ b/src/test/high-precision-values.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { parseCSV, formatRequestCount } from '@/lib/utils'
+
+const BASE_HEADERS = '"Timestamp","User","Model","Requests Used","Exceeds Monthly Quota","Total Monthly Quota"'
+
+describe('High-precision numeric values', () => {
+  it('should parse requestsUsed with many decimal digits without loss', () => {
+    const row = `"2025-06-11T05:13:27.8766440Z","alice","gpt-4o","107.03398500000002","False","Unlimited"`
+    const result = parseCSV(`${BASE_HEADERS}\n${row}`)
+    // parseFloat preserves IEEE 754 double precision
+    expect(result[0].requestsUsed).toBeCloseTo(107.033985, 6)
+  })
+
+  it('should parse small high-precision requestsUsed correctly', () => {
+    const row = `"2025-06-11T05:13:27.8766440Z","alice","gpt-4o","1.07033985","False","Unlimited"`
+    const result = parseCSV(`${BASE_HEADERS}\n${row}`)
+    expect(result[0].requestsUsed).toBeCloseTo(1.07033985, 8)
+  })
+
+  it('should preserve precision through aggregation', () => {
+    const rows = [
+      `"2025-06-11T05:00:00.0000000Z","alice","gpt-4o","107.03398500000002","False","Unlimited"`,
+      `"2025-06-11T06:00:00.0000000Z","alice","gpt-4o","1.07033985","False","Unlimited"`,
+    ]
+    const result = parseCSV(`${BASE_HEADERS}\n${rows.join('\n')}`)
+    const total = result.reduce((sum, r) => sum + r.requestsUsed, 0)
+    expect(total).toBeCloseTo(108.10432485, 6)
+  })
+})
+
+describe('formatRequestCount', () => {
+  it('should match toLocaleString with maximumFractionDigits 8 (locale-agnostic)', () => {
+    const cases = [5, 1000, 1.07033985, 107.03398500000002, 107.03]
+    for (const v of cases) {
+      const expected = v.toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 })
+      expect(formatRequestCount(v)).toBe(expected)
+    }
+  })
+
+  it('should preserve more precision than a 2-decimal format for high-precision values', () => {
+    const value = 107.03398500000002
+    const twoDP = value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
+    const result = formatRequestCount(value)
+    // Should have more digits than the 2dp version
+    expect(result).not.toBe(twoDP)
+    expect(result.length).toBeGreaterThan(twoDP.length)
+  })
+
+  it('should show whole numbers without decimal part', () => {
+    const result = formatRequestCount(5)
+    const expected = (5).toLocaleString(undefined, { maximumFractionDigits: 8, minimumFractionDigits: 0 })
+    expect(result).toBe(expected)
+    // Whole numbers must not have a decimal separator
+    const decSep = (1.1).toLocaleString(undefined, { maximumFractionDigits: 1 })[1]
+    expect(result).not.toContain(decSep)
+  })
+})
+


### PR DESCRIPTION
## Problem

The PRU CSV export contains high-precision request counts like \107.03398500000002\ and \1.07033985\. All display calls used \maximumFractionDigits: 2\, rounding these to \107.03\ and \1.07\ respectively — causing visible discrepancies when values were summed or compared.

## Changes

- **\src/lib/utils.ts\** — Added exported \ormatRequestCount(value)\ utility using \maximumFractionDigits: 8, minimumFractionDigits: 0\. This preserves up to 8 significant decimal digits and naturally drops floating-point noise (e.g. \107.03398500000002\ → \107.033985\).
- **\src/App.tsx\** — All 23 request count display calls updated from \maximumFractionDigits: 2\ to \maximumFractionDigits: 8\. Cost/dollar displays and percentage displays are unchanged.
- **\src/components/AICCostChart.tsx\** — AIC quantity tooltip updated from 4 to 8 decimal places.
- **\src/test/high-precision-values.test.ts\** — New test file covering high-precision CSV parsing, aggregation precision, and \ormatRequestCount\ behaviour.

## Before / After

| Value in CSV | Before (2dp) | After (8dp) |
|---|---|---|
| \107.03398500000002\ | \107.03\ | \107.033985\ |
| \1.07033985\ | \1.07\ | \1.07033985\ |
| \5\ | \5\ | \5\ |