### PR TITLE
Fix overage chart Y axis: scale to actual max + 10% instead of fixed 100%

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2121,8 +2121,8 @@ function App() {
                       <YAxis
                         tick={{ fill: 'var(--foreground)' }}
                         tickLine={{ stroke: 'var(--border)' }}
-                        tickFormatter={(v) => `${v.toFixed(0)}%`}
-                        domain={[0, 100]}
+                        tickFormatter={(v) => `${v.toFixed(1)}%`}
+                        domain={[0, Math.min(100, Math.ceil(Math.max(...dailyOveruserData.map(d => d.percentage)) * 1.1))]}
                       />
                       <Tooltip
                         content={({ active, payload, label }) => {


### PR DESCRIPTION
## Problem
The "% Users with Overage Costs (Cumulative)" chart had a fixed Y axis domain of `[0, 100]`. When actual overage percentages are small (e.g. < 5%), the bars appear as a nearly invisible line at the bottom, making the chart useless for spotting trends or bumps.

## Solution
Changed the Y axis `domain` to dynamically compute the max based on actual data:

```
domain={[0, Math.min(100, Math.ceil(Math.max(...dailyOveruserData.map(d => d.percentage)) * 1.1))]}
```

- Takes the actual max percentage in the data
- Adds a 10% buffer so bars don't touch the top
- Caps at 100% so it never exceeds a percentage scale
- Also updated `tickFormatter` to show one decimal place (`1.1%` instead of `1%`) for better precision at small values