### PR TITLE
fix: pass unitLabel as prop to BehaviorScatterChart to fix crash on hover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -358,12 +358,14 @@ const WeeklyTopModelsChart = React.memo(function WeeklyTopModelsChart({
 type BehaviorScatterChartProps = {
   behaviorData: BehaviorScatterPoint[];
   displayUser: (name: string) => string;
+  unitLabel: string;
 };
 
 // Isolated the graph due to latency issues. Allows toggling segments without reprocessing data or re-rendering other graphs.
 const BehaviorScatterChart = React.memo(function BehaviorScatterChart({
   behaviorData,
   displayUser,
+  unitLabel,
 }: BehaviorScatterChartProps) {
   const [hiddenBehaviorSegments, setHiddenBehaviorSegments] = useState<Set<string>>(new Set());
 
@@ -2422,7 +2424,7 @@ function App() {
               </div>
             </div>
             <Separator className="mb-6" />
-            <BehaviorScatterChart behaviorData={behaviorData} displayUser={displayUser} />
+            <BehaviorScatterChart behaviorData={behaviorData} displayUser={displayUser} unitLabel={unitLabel} />
           </div>
         </div>
       )}


### PR DESCRIPTION
The unitLabel variable was defined inside the App component but used in the standalone BehaviorScatterChart component, causing a ReferenceError when hovering over a bubble in the User Behavior Segments chart. This fixes the crash by passing unitLabel as a prop.