### PR TITLE
Rebrand: Premium Requests Usage → AIC Usage terminology

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Custom Instructions
 
 ## Project Overview
-This is a **GitHub Copilot Premium Requests Usage Analyzer** - a React-based single-page application that visualizes GitHub Copilot premium request usage data from CSV exports. The primary goal is to help teams understand their Copilot usage patterns, model distribution, and quota status.
+This is a **GitHub Copilot AIC Usage Analyzer** - a React-based single-page application that visualizes GitHub Copilot AI Credits (AIC) usage data from CSV exports. The primary goal is to help teams understand their Copilot usage patterns, model distribution, and quota status.
 
 ## Architecture & Technology Stack
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
-# Deploying GitHub Copilot Premium Requests Usage Analyzer to GitHub Pages
+# Deploying GitHub Copilot AIC Usage Analyzer to GitHub Pages
 
-This document explains how to deploy the GitHub Copilot Premium Requests Usage Analyzer application to GitHub Pages.
+This document explains how to deploy the GitHub Copilot AIC Usage Analyzer application to GitHub Pages.
 
 ## Automatic Deployment with GitHub Actions
 

--- a/GITHUB_PAGES_DEPLOY.md
+++ b/GITHUB_PAGES_DEPLOY.md
@@ -1,6 +1,6 @@
 # GitHub Pages Deployment Guide
 
-This document provides detailed instructions for deploying the GitHub Copilot Premium Requests Usage Analyzer to GitHub Pages.
+This document provides detailed instructions for deploying the GitHub Copilot AIC Usage Analyzer to GitHub Pages.
 
 ## Understanding the Deployment Process
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# GitHub Copilot Premium Requests Usage Analyzer
+# GitHub Copilot AIC Usage Analyzer
 
-A single-page application that visualizes GitHub Copilot premium request usage data from CSV exports. This tool helps you understand your team's Copilot usage patterns.
+A single-page application that visualizes GitHub Copilot AI Credits (AIC) usage data from CSV exports. This tool helps you understand your team's Copilot usage patterns.
 
 ## Quick Start
 
-Need to analyze the premium requests CSV? 
-I created a SPA with Spark and Coding Agent to display an overview of the Premium Requests CSV that you can currently download (no API yet 😓), so share it where needed! 
+Need to analyze the AI Credits (AIC) usage CSV? 
+I created a SPA with Spark and Coding Agent to display an overview of the AIC Usage CSV that you can currently download (no API yet 😓), so share it where needed! 
  
-Hosted on GitHub Pages: [GitHub Copilot Premium Requests Usage Analyzer](https://xebia.github.io/github-copilot-premium-reqs-usage/)
+Hosted on GitHub Pages: [GitHub Copilot AIC Usage Analyzer](https://xebia.github.io/github-copilot-premium-reqs-usage/)
 
 Upload the CSV from the enterprise export (Billing and Licenses → Usage → Export dropdown right top)
  
@@ -56,7 +56,7 @@ Result:
 
 ## CSV Format
 
-The application accepts either of the following CSV export formats from GitHub Copilot premium requests:
+The application accepts either of the following CSV export formats from GitHub Copilot AI Credits (AIC) usage:
 
 **Original format (until October):**
 ```

--- a/build-for-pages.sh
+++ b/build-for-pages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to build the GitHub Copilot Premium Requests Usage Analyzer for GitHub Pages deployment
+# Script to build the GitHub Copilot AIC Usage Analyzer for GitHub Pages deployment
 # This script creates a version without Spark dependencies
 
 # Exit on error

--- a/deploy-to-pages.sh
+++ b/deploy-to-pages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to deploy the GitHub Copilot Premium Requests Usage Analyzer to GitHub Pages manually
+# Script to deploy the GitHub Copilot AIC Usage Analyzer to GitHub Pages manually
 
 # Exit on error
 set -e

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Xebia - Copilot Premium Requests Usage Analyzer</title>
+    <title>Xebia - Copilot AIC Usage Analyzer</title>
     <link rel="stylesheet" href="/src/main.css" />
     <link rel="stylesheet" href="/src/index.css" />
     <link rel="icon" href="xebia-logo.png" type="image/png" />

--- a/push-and-deploy.md
+++ b/push-and-deploy.md
@@ -1,6 +1,6 @@
 # Deploying to GitHub Pages
 
-This document explains how to deploy the GitHub Copilot Premium Requests Usage Analyzer to GitHub Pages.
+This document explains how to deploy the GitHub Copilot AIC Usage Analyzer to GitHub Pages.
 
 ## Automated Deployment with GitHub Actions
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1194,7 +1194,7 @@ function App() {
           <div className="flex items-center gap-4">
             <img src="xebia-logo.png" alt="Xebia Logo" className="h-10" />
             <h1 className="text-3xl font-bold tracking-tight text-foreground">
-              GitHub Copilot Premium Requests Usage Analyzer
+              GitHub Copilot AIC Usage Analyzer
             </h1>
           </div>
           <div className="flex items-center gap-2">
@@ -1280,7 +1280,7 @@ function App() {
                 ? "Please wait while we process your files..." 
                 : isDragging 
                   ? "Drop your files here..." 
-                  : "Upload your GitHub Copilot premium requests usage CSV exports to visualize the data. You can select multiple files at once — they will be merged automatically."}
+                  : "Upload your GitHub Copilot AI Credits (AIC) usage CSV exports to visualize the data. You can select multiple files at once — they will be merged automatically."}
             </p>
             
             <Button 
@@ -1310,7 +1310,7 @@ function App() {
                 <ol className="list-decimal list-inside text-sm text-muted-foreground space-y-1.5">
                   <li>Open your GitHub <span className="font-medium text-foreground">organization</span> or <span className="font-medium text-foreground">enterprise</span> settings.</li>
                   <li>Go to <span className="font-medium text-foreground">Billing and licensing</span> → <span className="font-medium text-foreground">Usage</span>.</li>
-                  <li>Select the <span className="font-medium text-foreground">Copilot premium requests usage report</span>, choose a date range, then click <span className="font-medium text-foreground">Export CSV</span>.</li>
+                  <li>Select the <span className="font-medium text-foreground">Copilot AIC usage report</span>, choose a date range, then click <span className="font-medium text-foreground">Export CSV</span>.</li>
                   <li>Download the CSV, then drop it above or click "Select CSV Files".</li>
                 </ol>
                 <a

--- a/src/prd.md
+++ b/src/prd.md
@@ -1,7 +1,7 @@
-# GitHub Copilot Premium Requests Usage Analyzer
+# GitHub Copilot AIC Usage Analyzer
 
 ## Core Purpose & Success
-- **Mission Statement**: A tool that visualizes GitHub Copilot premium request usage to help teams monitor and optimize their AI resource consumption.
+- **Mission Statement**: A tool that visualizes GitHub Copilot AI Credits (AIC) usage to help teams monitor and optimize their AI resource consumption.
 - **Success Indicators**: Users can upload CSV data and quickly understand usage patterns, model distribution, and quota status through clear visualizations.
 - **Experience Qualities**: Efficient, Insightful, Professional
 


### PR DESCRIPTION
## What
GitHub has renamed "premium requests" billing to "AI Credits (AIC)". This PR updates the app's general branding and user-facing copy accordingly.

- App title/header: "GitHub Copilot Premium Requests Usage Analyzer" → "GitHub Copilot AIC Usage Analyzer" (`index.html`, `src/App.tsx`, `README.md`, `src/prd.md`)
- Generic descriptive copy: "premium request(s) usage" → "AI Credits (AIC) usage" in README, upload instructions, and `.github/copilot-instructions.md`
- Deployment docs/scripts (`DEPLOYMENT.md`, `GITHUB_PAGES_DEPLOY.md`, `push-and-deploy.md`, `build-for-pages.sh`, `deploy-to-pages.sh`) updated to match the new app name

## What was intentionally left unchanged
- The **repo name** (`github-copilot-premium-reqs-usage`) — will be renamed separately as requested.
- The **legacy "All Premium Requests" cost breakdown** section in the Potential Cost dialog, `PremiumCostChart`, and the `premiumRequests` stat in `UserSearch.tsx` — these are tied to the distinct `requestsUsed` field and `EXCESS_REQUEST_COST`, a separate legacy per-request billing calculation still supported for old-format CSVs, functionally different from the `aicQuantity`/`aicGrossAmount` fields already used by the existing `AICCostChart` feature. Renaming these would conflate two different data concepts.
- "Premium Models" terminology (model tier/multiplier concept, unrelated to the premium-request billing unit rename).

## Verification
- `npm run build` succeeds
- `npm run test -- --run` → 239/239 tests passing
- Verified in browser preview that the header now reads "GitHub Copilot AIC Usage Analyzer"